### PR TITLE
allocrunner: Fix update priority func to return typical update.

### DIFF
--- a/allocrunnersim/allocrunnersim.go
+++ b/allocrunnersim/allocrunnersim.go
@@ -192,7 +192,7 @@ func (ar *simulatedAllocRunner) GetTaskDriverCapabilities(taskName string) (*dri
 }
 
 func (ar *simulatedAllocRunner) GetUpdatePriority(_ *structs.Allocation) cstructs.AllocUpdatePriority {
-	return 0
+	return 1
 }
 
 func (ar *simulatedAllocRunner) StatsReporter() interfaces.AllocStatsReporter { return ar }


### PR DESCRIPTION
The previous value of zero, meant all updates were being dropped which blocked deployment updates among other events.