### PR TITLE
docker: add iptables package to Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN go build -o nomad-nodesim .
 FROM debian:stable AS dev
 
 RUN apt update
-RUN apt install -y iproute2
+RUN apt install -y \
+    iptables \
+    iproute2
 
 COPY --from=devbuild /build/nomad-nodesim /bin/


### PR DESCRIPTION
I plan to do nefarious things with the nomad-nodesim containers, and iptables manipulation will be one of those things.