### PR TITLE
allocrunner: handle alloc updates from job stop.

### DIFF
--- a/simnode/simnode.go
+++ b/simnode/simnode.go
@@ -21,6 +21,6 @@ func New(c *client.Client, logger hclog.Logger) *Node {
 }
 
 func (n *Node) Shutdown() error {
-	n.logger.Debug("shuting down...")
+	n.logger.Debug("shutting down")
 	return n.Client.Shutdown()
 }


### PR DESCRIPTION
This change adds minor functionality to handle job stops which are handled within the alloc-runner by the update function. When an allocation update is pulled from the servers, the simulated runner can now handle transitions to stop by correctly modifying alloc state parameters.