### PR TITLE
allocrunner: ensure alloc state updates are handled correctly.

### DIFF
--- a/allocrunnersim/allocrunnersim.go
+++ b/allocrunnersim/allocrunnersim.go
@@ -15,19 +15,34 @@ import (
 	cinterfaces "github.com/hashicorp/nomad/client/interfaces"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/device"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"golang.org/x/exp/maps"
 )
 
+const (
+	// taskEventMessagePrefix should be used as a prefix to all task event
+	// messages. It helps consistency and makes it clear which events are
+	// coming from the simulated runner.
+	taskEventMessagePrefix = "A nodesim task event happened: "
+)
+
 type simulatedAllocRunner struct {
-	c          cinterfaces.AllocStateHandler
-	logger     hclog.Logger
-	id         string
-	alloc      *structs.Allocation
-	allocState *state.State
-	allocLock  sync.RWMutex
+	c      cinterfaces.AllocStateHandler
+	logger hclog.Logger
+	id     string
+
+	alloc     *structs.Allocation
+	allocLock sync.RWMutex
+
+	allocState     *state.State
+	allocStateLock sync.RWMutex
+
+	// lastAcknowledgedState is the alloc runner state that was last
+	// acknowledged by the server. It may lag behind allocState.
+	lastAcknowledgedState *state.State
 }
 
 func NewEmptyAllocRunnerFunc(conf *config.AllocRunnerConfig) (interfaces.AllocRunner, error) {
@@ -58,69 +73,225 @@ func (ar *simulatedAllocRunner) taskNamesLocked() []string {
 func (ar *simulatedAllocRunner) Run() {
 	ar.logger.Info("running allocation")
 
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		ar.allocState.TaskStates = map[string]*structs.TaskState{}
-		for _, task := range ar.taskNamesLocked() {
-			ar.allocState.TaskStates[task] = structs.NewTaskState()
-			ar.allocState.TaskStates[task].StartedAt = time.Now()
-			ar.allocState.TaskStates[task].State = structs.TaskStateRunning
+	// Pull the tasks from the alloc-runner, so we only have to do this once.
+	allocRunnerTasks := ar.Alloc().Job.LookupTaskGroup(ar.alloc.TaskGroup).Tasks
+
+	// Track the tasks states directly within this function. This is fine as
+	// there is no outside influence of them such as an actual task runner.
+	taskStates := make(map[string]*structs.TaskState, len(allocRunnerTasks))
+
+	// This point marks the point where we add task events and eventually mark
+	// them as started.
+	for _, task := range allocRunnerTasks {
+
+		taskStates[task.Name] = structs.NewTaskState()
+
+		event := &structs.TaskEvent{
+			Type:    structs.TaskSetup,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskSetup,
+		}
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+	}
+	ar.updateAllocAndSendUpdate(taskStates)
+
+	// Let us pretend we are building a task directory, which is a fairly
+	// common event to see.
+	time.Sleep(100 * time.Millisecond)
+	ar.logger.Debug("building task directory")
+
+	for _, task := range allocRunnerTasks {
+		event := &structs.TaskEvent{
+			Type:    structs.TaskBuildingTaskDir,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskBuildingTaskDir,
+		}
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+	}
+	ar.updateAllocAndSendUpdate(taskStates)
+
+	// Trigger a task hook which is normal operation when starting a typical
+	// Nomad task.
+	time.Sleep(200 * time.Millisecond)
+	ar.logger.Debug("firing a task hook")
+
+	for _, task := range allocRunnerTasks {
+		event := &structs.TaskEvent{
+			Type:    structs.TaskHookMessage,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskHookMessage,
+		}
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+	}
+	ar.updateAllocAndSendUpdate(taskStates)
+
+	// Trigger another task hook, which is normal operation when starting a
+	// typical Nomad task.
+	time.Sleep(100 * time.Millisecond)
+	ar.logger.Debug("firing another task hook")
+
+	for _, task := range allocRunnerTasks {
+		event := &structs.TaskEvent{
+			Type:    structs.TaskHookMessage,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskHookMessage,
+		}
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+	}
+	ar.updateAllocAndSendUpdate(taskStates)
+
+	// The tasks are now started. Add a task event to detail this and also
+	// modify the state to indicate this and when it happened.
+	time.Sleep(500 * time.Millisecond)
+	ar.logger.Debug("marking all tasks as started")
+
+	for _, task := range allocRunnerTasks {
+
+		event := &structs.TaskEvent{
+			Type:    structs.TaskStarted,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskStarted,
+		}
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+
+		taskStates[task.Name].StartedAt = time.Now()
+		taskStates[task.Name].State = structs.TaskStateRunning
+	}
+
+	// Mark the deployment as healthy by directly manipulating the state
+	// object. This ensures the Nomad CLI will return when polling the job
+	// registration deployment.
+	time.Sleep(100 * time.Millisecond)
+	ar.logger.Debug("marking deployment as healthy")
+
+	ar.allocStateLock.Lock()
+	ar.allocState.DeploymentStatus = &structs.AllocDeploymentStatus{Healthy: pointer.Of(true), Timestamp: time.Now()}
+	ar.allocStateLock.Unlock()
+
+	ar.updateAllocAndSendUpdate(taskStates)
+}
+
+// updateAllocAndSendUpdate is a small helper that builds a new allocation
+// object from the potentially updated task states. This function should be
+// called whenever a change has happened that you want sent to the servers. The
+// change might not be immediately sent and is calculated according to
+// GetUpdatePriority.
+func (ar *simulatedAllocRunner) updateAllocAndSendUpdate(taskStates map[string]*structs.TaskState) {
+	hydratedAlloc := ar.clientAlloc(taskStates)
+	ar.c.AllocStateUpdated(hydratedAlloc)
+}
+
+// clientAlloc is lifted from Nomad and populates a new allocation based on the
+// current alloc state.
+func (ar *simulatedAllocRunner) clientAlloc(taskStates map[string]*structs.TaskState) *structs.Allocation {
+	ar.allocStateLock.Lock()
+	defer ar.allocStateLock.Unlock()
+
+	// store task states for AllocState to expose
+	ar.allocState.TaskStates = taskStates
+
+	a := &structs.Allocation{
+		ID:         ar.id,
+		TaskStates: taskStates,
+	}
+
+	if d := ar.allocState.DeploymentStatus; d != nil {
+		a.DeploymentStatus = d.Copy()
+	}
+
+	// Compute the ClientStatus
+	if ar.allocState.ClientStatus != "" {
+		// The client status is being forced
+		a.ClientStatus, a.ClientDescription = ar.allocState.ClientStatus, ar.allocState.ClientDescription
+	} else {
+		a.ClientStatus, a.ClientDescription = getClientStatus(taskStates)
+	}
+
+	// If the allocation is terminal, make sure all required fields are properly
+	// set.
+	if a.ClientTerminalStatus() {
+		alloc := ar.Alloc()
+
+		// If we are part of a deployment and the alloc has failed, mark the
+		// alloc as unhealthy. This guards against the watcher not be started.
+		// If the health status is already set then terminal allocations should not
+		if a.ClientStatus == structs.AllocClientStatusFailed &&
+			alloc.DeploymentID != "" && !a.DeploymentStatus.HasHealth() {
+			a.DeploymentStatus = &structs.AllocDeploymentStatus{
+				Healthy: pointer.Of(false),
+			}
 		}
 
-		ar.appendTaskEventForLocked(structs.TaskSetup)
-		ar.alloc.TaskStates = ar.allocState.TaskStates
-	})
+		// Make sure we have marked the finished at for every task. This is used
+		// to calculate the reschedule time for failed allocations.
+		now := time.Now()
+		for _, taskName := range ar.taskNamesLocked() {
+			ts, ok := a.TaskStates[taskName]
+			if !ok {
+				ts = &structs.TaskState{}
+				a.TaskStates[taskName] = ts
+			}
+			if ts.FinishedAt.IsZero() {
+				ts.FinishedAt = now
+			}
+		}
+	}
 
-	time.Sleep(100 * time.Millisecond)
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		ar.logger.Debug("building taskdir", "alloc_id", ar.id)
-		ar.appendTaskEventForLocked(structs.TaskBuildingTaskDir)
-	})
+	// Set the NetworkStatus and default DNSConfig if one is not returned from the client
+	netStatus := ar.allocState.NetworkStatus
+	if netStatus != nil {
+		a.NetworkStatus = netStatus
+	} else {
+		a.NetworkStatus = new(structs.AllocNetworkStatus)
+	}
 
-	time.Sleep(200 * time.Millisecond)
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		ar.logger.Debug("firing a task hook", "alloc_id", ar.id)
-		ar.appendTaskEventForLocked(structs.TaskHookMessage)
-	})
+	if a.NetworkStatus.DNS == nil {
+		alloc := ar.Alloc()
+		nws := alloc.Job.LookupTaskGroup(alloc.TaskGroup).Networks
+		if len(nws) > 0 {
+			a.NetworkStatus.DNS = nws[0].DNS.Copy()
+		}
+	}
 
-	time.Sleep(100 * time.Millisecond)
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		ar.logger.Debug("firing another task hook", "alloc_id", ar.id)
-		ar.appendTaskEventForLocked(structs.TaskHookMessage)
-	})
-
-	time.Sleep(500 * time.Millisecond)
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		ar.logger.Debug("tasks are started", "alloc_id", ar.id)
-		ar.appendTaskEventForLocked(structs.TaskStarted)
-		ar.allocState.ClientStatus = "running"
-		ar.alloc.ClientStatus = "running"
-		ar.allocState.SetDeploymentStatus(time.Now(), true)
-		ar.alloc.DeploymentStatus = ar.allocState.DeploymentStatus.Copy()
-	})
-
+	return a
 }
 
-// updateAllocAndSendUpdate is a helper that updates the allocrunner state while
-// the allocLock is held, and then queues-up a server update
-func (ar *simulatedAllocRunner) updateAllocAndSendUpdate(updateFn func(*simulatedAllocRunner)) {
-	ar.allocLock.Lock()
-	updateFn(ar)
-	ar.c.AllocStateUpdated(ar.alloc)
-	ar.allocLock.Unlock()
-}
-
-func (ar *simulatedAllocRunner) appendTaskEventForLocked(eventType string) {
-	event := &structs.TaskEvent{
-		Type:    eventType,
-		Time:    time.Now().UnixNano(),
-		Message: "a task event happened: " + eventType,
+// getClientStatus takes in the task states for a given allocation and computes
+// the client status and description.
+func getClientStatus(taskStates map[string]*structs.TaskState) (status, description string) {
+	var pending, running, dead, failed bool
+	for _, taskState := range taskStates {
+		switch taskState.State {
+		case structs.TaskStateRunning:
+			running = true
+		case structs.TaskStatePending:
+			pending = true
+		case structs.TaskStateDead:
+			if taskState.Failed {
+				failed = true
+			} else {
+				dead = true
+			}
+		}
 	}
-	event.PopulateEventDisplayMessage()
 
-	for _, task := range ar.taskNamesLocked() {
-		ar.allocState.TaskStates[task].Events = append(ar.allocState.TaskStates[task].Events, event)
-		ar.alloc.TaskStates = ar.allocState.TaskStates
+	// Determine the alloc status
+	if failed {
+		return structs.AllocClientStatusFailed, "Failed tasks"
+	} else if running {
+		return structs.AllocClientStatusRunning, "Tasks are running"
+	} else if pending {
+		return structs.AllocClientStatusPending, "No tasks have started"
+	} else if dead {
+		return structs.AllocClientStatusComplete, "All tasks have completed"
 	}
+
+	return "", ""
 }
 
 func (ar *simulatedAllocRunner) Restore() error { return nil }
@@ -145,29 +316,50 @@ func (ar *simulatedAllocRunner) Update(update *structs.Allocation) {
 
 func (ar *simulatedAllocRunner) stopAll() {
 
-	// Modify the task states, so that they report as "dead" meaning they are
-	// terminal.
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		for _, task := range ar.taskNamesLocked() {
-			ar.allocState.TaskStates[task].FinishedAt = time.Now()
-			ar.allocState.TaskStates[task].State = structs.TaskStateDead
+	// Get the current list of task being run by the alloc-runner, so we can
+	// iterate this as many times as needed.
+	ar.allocLock.RLock()
+	allocRunnerTasks := ar.Alloc().Job.LookupTaskGroup(ar.alloc.TaskGroup).Tasks
+	ar.allocLock.RUnlock()
+
+	// Ensure we have a current copy of the task states, so that we append and
+	// create a correct and full list.
+	ar.allocStateLock.RLock()
+	taskStates := ar.allocState.TaskStates
+	ar.allocStateLock.RUnlock()
+
+	// Perform the task kill, which essentially is the shutdown notification.
+	ar.logger.Debug("performing task kill")
+
+	for _, task := range allocRunnerTasks {
+		event := &structs.TaskEvent{
+			Type:    structs.TaskKilling,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskKilling,
 		}
-		ar.alloc.TaskStates = ar.allocState.TaskStates
-	})
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+	}
+	ar.updateAllocAndSendUpdate(taskStates)
 
-	// Sleep a little, we don't want things to go too fast now, do we?
-	time.Sleep(100 * time.Millisecond)
+	// Mark the tasks as killed and ensure the state is updated to show they
+	// are dead and finished.
+	time.Sleep(200 * time.Millisecond)
+	ar.logger.Debug("marking task as killed")
 
-	// Update the overall allocation status to indicate the tasks have stopped
-	// and the allocation, therefore, is complete.
-	ar.updateAllocAndSendUpdate(func(ar *simulatedAllocRunner) {
-		ar.logger.Debug("tasks are shutdown", "alloc_id", ar.id)
-		ar.appendTaskEventForLocked(structs.TaskKilled)
-		ar.allocState.ClientStatus = structs.AllocClientStatusComplete
-		ar.alloc.ClientStatus = structs.AllocClientStatusComplete
-		ar.alloc.ClientDescription = "All tasks have completed"
-		ar.allocState.ClientDescription = "All tasks have completed"
-	})
+	for _, task := range allocRunnerTasks {
+		event := &structs.TaskEvent{
+			Type:    structs.TaskKilled,
+			Time:    time.Now().UnixNano(),
+			Message: taskEventMessagePrefix + structs.TaskKilled,
+		}
+		event.PopulateEventDisplayMessage()
+		taskStates[task.Name].Events = append(taskStates[task.Name].Events, event)
+
+		ar.allocState.TaskStates[task.Name].FinishedAt = time.Now()
+		ar.allocState.TaskStates[task.Name].State = structs.TaskStateDead
+	}
+	ar.updateAllocAndSendUpdate(taskStates)
 
 	ar.logger.Info("stopped all alloc-runner tasks and marked as complete")
 }
@@ -201,17 +393,17 @@ func (ar *simulatedAllocRunner) ShutdownCh() <-chan struct{} {
 }
 
 func (ar *simulatedAllocRunner) AllocState() *state.State {
-	ar.allocLock.RLock()
-	defer ar.allocLock.RUnlock()
+	ar.allocStateLock.RLock()
+	defer ar.allocStateLock.RUnlock()
 	return ar.allocState.Copy()
 }
 
 func (ar *simulatedAllocRunner) PersistState() error { return nil }
 
 func (ar *simulatedAllocRunner) AcknowledgeState(allocState *state.State) {
-	ar.allocLock.Lock()
-	defer ar.allocLock.Unlock()
-	ar.allocState = allocState
+	ar.allocStateLock.Lock()
+	defer ar.allocStateLock.Unlock()
+	ar.lastAcknowledgedState = allocState
 }
 
 func (ar *simulatedAllocRunner) SetClientStatus(status string) {
@@ -238,10 +430,10 @@ func (ar *simulatedAllocRunner) GetTaskDriverCapabilities(taskName string) (*dri
 }
 
 func (ar *simulatedAllocRunner) GetUpdatePriority(alloc *structs.Allocation) cstructs.AllocUpdatePriority {
-	ar.allocLock.RLock()
-	defer ar.allocLock.RUnlock()
+	ar.allocStateLock.RLock()
+	defer ar.allocStateLock.RUnlock()
 
-	last := ar.allocState
+	last := ar.lastAcknowledgedState
 	if last == nil {
 		if alloc.ClientStatus == structs.AllocClientStatusFailed {
 			return cstructs.AllocUpdatePriorityUrgent


### PR DESCRIPTION
Implementing the GetUpdatePriority function is not enough to ensure updates are handling in a similar fashion to real clients.

The alloc runner needs to be careful in how and when it updates its own state. Specifically, we do not want to directly force the client status information and instead have this populated once updates have been sent to the servers. The new functionality helps ensure updates are sent at the correct pacing, and handled in a manner more similar to real clients.