### PR TITLE
config: allow configuration of node CPU and memory resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ config file in [HCL](https://github.com/hashicorp/hcl) format.
 
 - `region` - (`"dc1"`) - Specifies the region of the `nomad-nodesim` clients.
 
+- `resources` - (block) - The CPU and Memory configuration that will be given to the simulated
+  node.
+
+  - `cpu_compute` - (`10_000`)  - The CPU value that the simulated node will be configured with and
+    will represent the total allocatable CPU of the client.
+
+  - `memory_mb` - (`10_000`)  - The memory MB value that the simulated node will be configured with and
+    will represent the total allocatable memory of the client.
+
 - `options` - (`"map[string]string"`) - Specifies a key-value mapping of internal configuration for
   `nomad-nodesim` clients, such as for driver configuration.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,15 @@ type Node struct {
 	// required, or which have lengthy timeouts which can slow client startup
 	// times.
 	Options map[string]string `hcl:"options,optional"`
+
+	Resources *NodeResource `hcl:"resources,block"`
+}
+
+// NodeResource is the CPU and Memory configuration that will be given to the
+// simulated node.
+type NodeResource struct {
+	CPUCompute uint64 `hcl:"cpu_compute,optional"`
+	MemoryMB   uint64 `hcl:"memory_mb,optional"`
 }
 
 // Default returns a default configuration object with all parameters set to
@@ -96,6 +105,10 @@ func Default() *Config {
 			NodePool:   "default",
 			NodeClass:  "",
 			Options:    map[string]string{},
+			Resources: &NodeResource{
+				CPUCompute: 10_000,
+				MemoryMB:   10_000,
+			},
 		},
 	}
 }
@@ -154,6 +167,14 @@ func (n *Node) merge(z *Node) *Node {
 	if z.Options != nil {
 		for k, v := range z.Options {
 			result.Options[k] = v
+		}
+	}
+	if z.Resources != nil {
+		if z.Resources.CPUCompute != 0 {
+			result.Resources.CPUCompute = z.Resources.CPUCompute
+		}
+		if z.Resources.MemoryMB != 0 {
+			result.Resources.MemoryMB = z.Resources.MemoryMB
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -37,8 +37,10 @@ func main() {
 	defer stop()
 
 	flagConfig := internalConfig.Config{
-		Log:  &internalConfig.Log{},
-		Node: &internalConfig.Node{},
+		Log: &internalConfig.Log{},
+		Node: &internalConfig.Node{
+			Resources: &internalConfig.NodeResource{},
+		},
 	}
 
 	flag.StringVar(&flagConfig.WorkDir, "work-dir", "", "working directory")
@@ -188,8 +190,8 @@ func startClient(logger hclog.Logger, buildInfo *internalSimnode.BuildInfo, cfg 
 
 	// Fake resources
 	clientCfg.NetworkSpeed = 1_000
-	clientCfg.CpuCompute = 10_000
-	clientCfg.MemoryMB = 10_000
+	clientCfg.CpuCompute = int(cfg.Node.Resources.CPUCompute)
+	clientCfg.MemoryMB = int(cfg.Node.Resources.MemoryMB)
 
 	clientCfg.MaxKillTimeout = time.Minute
 


### PR DESCRIPTION
horse-sized duck, or a duck-sized horses?